### PR TITLE
exclude installation of top-level test directory (IDFGH-12969)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
 ]
 
 [tool.setuptools.packages]
-find = {}
+find = {exclude = ["test", "test.*"]}
 
 [tool.setuptools.dynamic]
 version = {attr = "esp_idf_kconfig.__version__"}


### PR DESCRIPTION
Previously, test directory was installed at top-level in site-pacakges (e.g: /usr/lib/python3.12/site-packages/test). This patch excludes the test directory from installing in the first place.