### PR TITLE
fix: Add rich as a missing dependency (IDFGH-15593)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "windows-curses; sys_platform == 'win32' and python_version < '3.13'",
     # older versions does not support Python 3.13: https://github.com/zephyrproject-rtos/windows-curses/issues/69
     "windows-curses>=2.4.1; sys_platform == 'win32' and python_version >= '3.13'",
+    "rich",
 ]
 [project.urls]
 Homepage = "https://github.com/espressif/esp-idf-kconfig"
@@ -45,7 +46,6 @@ dev = [
     "pexpect",
     "pyparsing",
     "pytest",
-    "rich",
 ]
 docs = [
     "esp-docs~=1.5"


### PR DESCRIPTION
## Description
Hi, I have an error during the execution due to the module `rich` as a dependency not installed nor mentioned in pyproject.toml.
The full stacktrace is lost but it's the same as here (on Windows, I'm on GNU/Linux):  schreibfaul1/ESP32-MiniWebRadio#697

Problematic line: https://github.com/espressif/esp-idf-kconfig/blob/7c147bf6b0303d6f293e389d9a87774b31ed386a/kconfiglib/report.py#L29
```
from rich import print as rprint
ModuleNotFoundError: No module named 'rich'
```

I fixed the version 14.0.0 of rich since their release is from March, and yours from May.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
